### PR TITLE
Make two kinds of pattern language errors ignorable #143

### DIFF
--- a/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/plugin.xml
+++ b/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/plugin.xml
@@ -53,5 +53,11 @@
            provider="org.eclipse.viatra.query.patternlanguage.emf.annotations.impl.LabelAnnotationValidator" />
      <annotation
            provider="org.eclipse.viatra.query.patternlanguage.emf.annotations.impl.QueryExplorerAnnotationValidator" />
+     <annotation
+           provider="org.eclipse.viatra.query.patternlanguage.emf.annotations.impl.NegativeRecursionAnnotationValidator">
+     </annotation>
+     <annotation
+           provider="org.eclipse.viatra.query.patternlanguage.emf.annotations.impl.ModelObjectExpressionAnnotationValidator">
+     </annotation>
   </extension>
 </plugin>

--- a/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/annotations/impl/ModelObjectExpressionAnnotationValidator.java
+++ b/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/annotations/impl/ModelObjectExpressionAnnotationValidator.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2023, Gabor Bergmann, IncQuery Labs
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-v20.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.viatra.query.patternlanguage.emf.annotations.impl;
+
+import org.eclipse.viatra.query.patternlanguage.emf.annotations.PatternAnnotationValidator;
+
+/**
+ * @author BergmannG
+ * @since 2.8
+ *
+ */
+public class ModelObjectExpressionAnnotationValidator extends PatternAnnotationValidator {
+    
+    public static final String ANNOTATION_ID = "SafeModelObjectExpression";
+    private static final String ANNOTATION_DESCRIPTION = "EXPERT USERS ONLY. EXPERIMENTAL ANNOTATION, support may be removed from subsequent versions without notice. " +
+            "Patterns annotated with this are permitted to use model object variables in check() or eval() expressions, in addition to scalar attribute variables. " +
+            "WARNING: in this case static analysis cannot prove that the expression is deterministic (always yields the same result for the same variable substitution, even if the model is changed); " + 
+            "the query author is burdened with proving that the model objects are only processed in ways that yield a constant, deterministic result irrespective of model or environment changes.";
+    
+    
+    public ModelObjectExpressionAnnotationValidator() {
+        super(ANNOTATION_ID, ANNOTATION_DESCRIPTION, /*deprecated=*/true);
+    }
+
+}

--- a/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/annotations/impl/NegativeRecursionAnnotationValidator.java
+++ b/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/annotations/impl/NegativeRecursionAnnotationValidator.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2023, Gabor Bergmann, IncQuery Labs
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-v20.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.viatra.query.patternlanguage.emf.annotations.impl;
+
+import org.eclipse.viatra.query.patternlanguage.emf.annotations.PatternAnnotationValidator;
+
+/**
+ * @author BergmannG
+ * @since 2.8
+ *
+ */
+public class NegativeRecursionAnnotationValidator extends PatternAnnotationValidator {
+    
+    public static final String ANNOTATION_ID = "SafeNegativeRecursion";
+    private static final String ANNOTATION_DESCRIPTION = "EXPERT USERS ONLY. Patterns annotated with this are permitted to recurse through negative calls. " +
+            "WARNING: in this case static analysis cannot prove that the recursion is stratifiable (safe to compute); " + 
+            "the query author is burdened with proving that there is no contradictory recursion between tuples.";
+    
+    
+    public NegativeRecursionAnnotationValidator() {
+        super(ANNOTATION_ID, ANNOTATION_DESCRIPTION);
+    }
+
+}

--- a/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/helper/PatternLanguageHelper.java
+++ b/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/helper/PatternLanguageHelper.java
@@ -495,13 +495,38 @@ public final class PatternLanguageHelper {
      * @return the pattern body that contains the value reference
      */
     public static PatternBody containerPatternBody(ValueReference val) {
+        return containerPatternBody((EObject) val);
+    }
+
+    /**
+     * @return the pattern body that contains the value reference or pattern call
+     * @since 2.8
+     */
+    public static PatternBody containerPatternBody(EObject val) {
         for (EObject cursor = val; cursor!=null; cursor = cursor.eContainer())
             if (cursor instanceof PatternBody)
                 return (PatternBody) cursor;
         // cursor == null --> not contained in PatternBody
         throw new IllegalArgumentException(
                 String.format(
-                        "Misplaced value reference %s not contained in any pattern body",
+                        "Misplaced pattern definition element %s not contained in any pattern body",
+                        val));
+    }
+    
+    /**
+     * @return the pattern that contains the value reference or pattern call
+     * @since 2.8
+     */
+    public static Pattern containerPattern(EObject val) {
+        PatternBody body = containerPatternBody(val);
+        EObject container = body.eContainer();
+        if (container instanceof Pattern) {
+            return (Pattern) container;
+        }
+        // not contained in Pattern
+        throw new IllegalArgumentException(
+                String.format(
+                        "Misplaced pattern definition element %s not contained in any pattern",
                         val));
     }
 

--- a/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/validation/EMFPatternLanguageValidator.java
+++ b/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/validation/EMFPatternLanguageValidator.java
@@ -43,6 +43,7 @@ import org.eclipse.viatra.query.patternlanguage.emf.vql.PatternImport;
 import org.eclipse.viatra.query.patternlanguage.emf.vql.PatternModel;
 import org.eclipse.viatra.query.patternlanguage.emf.vql.ReferenceType;
 import org.eclipse.viatra.query.patternlanguage.emf.vql.VQLImportSection;
+import org.eclipse.viatra.query.patternlanguage.emf.annotations.impl.ModelObjectExpressionAnnotationValidator;
 import org.eclipse.viatra.query.patternlanguage.emf.helper.PatternLanguageHelper;
 import org.eclipse.viatra.query.patternlanguage.emf.jvmmodel.EMFPatternLanguageJvmModelInferrerUtil;
 import org.eclipse.viatra.query.patternlanguage.emf.services.EMFPatternLanguageGrammarAccess;
@@ -799,6 +800,9 @@ public class EMFPatternLanguageValidator extends AbstractEMFPatternLanguageValid
     }
 
     private void checkForWrongVariablesInXExpressionsInternal(final XExpression expression) {
+        boolean safeModelObject = 
+                PatternLanguageHelper.containerPattern(expression).getAnnotations().stream().anyMatch(annotation -> ModelObjectExpressionAnnotationValidator.ANNOTATION_ID.equals(annotation.getName()));
+        
         for (Variable variable : PatternLanguageHelper.getReferencedPatternVariablesOfXExpression(expression,
                 associations)) {
             IInputKey classifier = typeInferrer.getType(variable);
@@ -807,6 +811,7 @@ public class EMFPatternLanguageValidator extends AbstractEMFPatternLanguageValid
                         + variable.getName() + " has an unknown type.",
                         expression.eContainer(), null, IssueCodes.CHECK_CONSTRAINT_SCALAR_VARIABLE_ERROR);
             } else if (classifier != null && !(classifier instanceof EDataTypeInSlotsKey)
+                    && !safeModelObject
                     && !(classifier instanceof JavaTransitiveInstancesKey)) {// null-check needed, otherwise code throws
                                                                              // NPE for classifier.getName()
                 error("Only simple EDataTypes are allowed in check() and eval() expressions. The variable "


### PR DESCRIPTION
Moved Gerrit change from https://git.eclipse.org/r/c/viatra/org.eclipse.viatra/+/204875 and rebased it from current master.

@bergmanngabor Please verify the move is successful and if there is any information on the Gerrit change that needs to be kept indefinitely, copy it here. Thanks.