### PR TITLE
Refine warning for aggregating long path expression chains #136

### DIFF
--- a/query/plugins/org.eclipse.viatra.query.runtime/src/org/eclipse/viatra/query/runtime/emf/EMFQueryMetaContext.java
+++ b/query/plugins/org.eclipse.viatra.query.runtime/src/org/eclipse/viatra/query/runtime/emf/EMFQueryMetaContext.java
@@ -342,10 +342,10 @@ public final class EMFQueryMetaContext extends AbstractQueryMetaContext {
     }
 
     public boolean isFeatureMultiplicityToOne(EStructuralFeature feature) {
-        return isFeatureToOneMultiplicity(feature);
+        return isFeatureToOneMultiplicity(feature); // delegate legacy instance method to new static method
     }
     public boolean isFeatureMultiplicityOneTo(EStructuralFeature typeObject) {
-        return isFeatureMultiplicityOneTo(typeObject);
+        return isFeatureOneToMultiplicity(typeObject); // delegate legacy instance method to new static method
     }
     /**
      * @since 2.9

--- a/query/plugins/org.eclipse.viatra.query.runtime/src/org/eclipse/viatra/query/runtime/emf/EMFQueryMetaContext.java
+++ b/query/plugins/org.eclipse.viatra.query.runtime/src/org/eclipse/viatra/query/runtime/emf/EMFQueryMetaContext.java
@@ -340,12 +340,23 @@ public final class EMFQueryMetaContext extends AbstractQueryMetaContext {
     public void illegalInputKey(IInputKey key) {
         throw new IllegalArgumentException("The input key " + key + " is not a valid EMF input key.");
     }
-    
+
     public boolean isFeatureMultiplicityToOne(EStructuralFeature feature) {
+        return isFeatureToOneMultiplicity(feature);
+    }
+    public boolean isFeatureMultiplicityOneTo(EStructuralFeature typeObject) {
+        return isFeatureMultiplicityOneTo(typeObject);
+    }
+    /**
+     * @since 2.9
+     */
+    public static boolean isFeatureToOneMultiplicity(EStructuralFeature feature) {
         return !feature.isMany();
     }
-
-    public boolean isFeatureMultiplicityOneTo(EStructuralFeature typeObject) {
+    /**
+     * @since 2.9
+     */
+    public static boolean isFeatureOneToMultiplicity(EStructuralFeature typeObject) {
         if (typeObject instanceof EReference) {
             final EReference feature = (EReference)typeObject;
             final EReference eOpposite = feature.getEOpposite();


### PR DESCRIPTION
Fixes #136 

Raise the warning for aggregating feature chains only if the intermediate values are not uniquely determined by the path expression source and target.