### PR TITLE
Fix NPE in VQE wipe/dispose -> EVM -> MatchUpdateListener chains #132

### DIFF
--- a/query/plugins/org.eclipse.viatra.query.runtime.rete/src/org/eclipse/viatra/query/runtime/rete/matcher/ReteEngine.java
+++ b/query/plugins/org.eclipse.viatra.query.runtime.rete/src/org/eclipse/viatra/query/runtime/rete/matcher/ReteEngine.java
@@ -262,6 +262,7 @@ public class ReteEngine implements IQueryBackend {
      * @since 2.4
      */
     public <T> T constructionWrapper(final Callable<T> payload) {
+        ensureInitialized();
         T result = null;
 //		context.modelReadLock();
 //		    try {
@@ -533,6 +534,13 @@ public class ReteEngine implements IQueryBackend {
 
     }
     
+    /**
+     * @since 2.9
+     */
+    public boolean isDisposedOrUninitialized() {
+        return disposedOrUninitialized;
+    }
+
     @Override
     public IQueryResultProvider getResultProvider(PQuery query)  {
         return accessMatcher(query);

--- a/query/plugins/org.eclipse.viatra.query.runtime.rete/src/org/eclipse/viatra/query/runtime/rete/matcher/RetePatternMatcher.java
+++ b/query/plugins/org.eclipse.viatra.query.runtime.rete/src/org/eclipse/viatra/query/runtime/rete/matcher/RetePatternMatcher.java
@@ -450,6 +450,7 @@ public class RetePatternMatcher extends TransformerNode implements IQueryResultP
 
     @Override
     public void removeUpdateListener(Object listenerTag) {
+        if (engine.isDisposedOrUninitialized()) return; // NO-OP
         engine.constructionWrapper(() -> {
             disconnectByTag(listenerTag);
             return null;

--- a/transformation/tests/org.eclipse.viatra.transformation.evm.tests/test/org/eclipse/viatra/transformation/evm/test/LifecycleTest.java
+++ b/transformation/tests/org.eclipse.viatra.transformation.evm.tests/test/org/eclipse/viatra/transformation/evm/test/LifecycleTest.java
@@ -18,6 +18,9 @@ import org.eclipse.viatra.examples.cps.cyberPhysicalSystem.CyberPhysicalSystemPa
 import org.eclipse.viatra.gui.tests.queries.IdIsNotUnique;
 import org.eclipse.viatra.gui.tests.queries.IdIsNotUnique.Match;
 import org.eclipse.viatra.query.runtime.api.AdvancedViatraQueryEngine;
+import org.eclipse.viatra.query.runtime.api.IPatternMatch;
+import org.eclipse.viatra.query.runtime.api.ViatraQueryEngineLifecycleListener;
+import org.eclipse.viatra.query.runtime.api.ViatraQueryMatcher;
 import org.eclipse.viatra.query.runtime.emf.EMFScope;
 import org.eclipse.viatra.transformation.evm.api.ExecutionSchema;
 import org.eclipse.viatra.transformation.evm.api.Job;
@@ -74,5 +77,30 @@ public class LifecycleTest {
         schema.dispose();
     }
 
-    
+    @Test
+    public void initAndShutdownWithPropagatingLifecycleListener() {
+        AdvancedViatraQueryEngine queryEngine = initializeQueryEngine();
+        ExecutionSchema schema = initializeExecutionSchema(queryEngine);
+        queryEngine.addLifecycleListener(new ViatraQueryEngineLifecycleListener() {
+            
+            @Override
+            public void matcherInstantiated(ViatraQueryMatcher<? extends IPatternMatch> matcher) {
+            }
+            
+            @Override
+            public void engineWiped() {
+                schema.dispose(); // reproduces bug #132
+            }
+            
+            @Override
+            public void engineDisposed() {
+            }
+            
+            @Override
+            public void engineBecameTainted(String message, Throwable t) {
+            }
+        });
+        queryEngine.dispose();
+    }
+
 }


### PR DESCRIPTION
Fixes #132 

Make sure that match update listener removal is a NO-OP for a Rete engine under wiping.