### PR TITLE
Updates Eclipse Collections dependency to 11.1 #145

### DIFF
--- a/documentation/org.eclipse.viatra.documentation.example/META-INF/MANIFEST.MF
+++ b/documentation/org.eclipse.viatra.documentation.example/META-INF/MANIFEST.MF
@@ -16,8 +16,7 @@ Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.core.runtime,
  org.eclipse.emf.codegen,
  org.eclipse.emf.codegen.ecore,
- org.eclipse.viatra.query.runtime.base.itc;bundle-version="2.0.0",
- org.eclipse.collections;bundle-version="10.1.0"
+ org.eclipse.viatra.query.runtime.base.itc;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: javax.annotation,
  org.apache.log4j

--- a/maven/viatra-query-runtime/pom.xml
+++ b/maven/viatra-query-runtime/pom.xml
@@ -88,12 +88,12 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
-            <version>10.2.0</version>
+            <version>11.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
-            <version>10.2.0</version>
+            <version>11.1.0</version>
         </dependency>
     </dependencies>
     <parent>

--- a/query/plugins/org.eclipse.viatra.query.runtime.matchers/META-INF/MANIFEST.MF
+++ b/query/plugins/org.eclipse.viatra.query.runtime.matchers/META-INF/MANIFEST.MF
@@ -41,5 +41,5 @@ Export-Package: org.eclipse.viatra.query.runtime.matchers,
  org.eclipse.viatra.query.runtime.matchers.util.timeline
 Bundle-ClassPath: .
 Import-Package: org.apache.log4j;version="1.2.15"
-Require-Bundle: org.eclipse.collections;bundle-version="10.1.0"
+Require-Bundle: org.eclipse.collections;bundle-version="11.0.0"
 Automatic-Module-Name: org.eclipse.viatra.query.runtime.matchers

--- a/releng/org.eclipse.viatra.setup/VIATRAEMF.setup
+++ b/releng/org.eclipse.viatra.setup/VIATRAEMF.setup
@@ -540,6 +540,8 @@
         <requirement
             name="org.eclipse.uml2.sdk.feature.group"
             versionRange="[5.0.0,6.0.0)"/>
+        <requirement
+            name="org.eclipse.collections.feature.source.feature.group"/>
         <repositoryList
             name="2022-06">
           <repository
@@ -758,18 +760,6 @@
               url="http://download.eclipse.org/releases/2024-03"/>
           <repository
               url="http://download.itemis.com/updates/releases/2.1.1/"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Eclipse Collections"
-          activeRepositoryList="10.2.0">
-        <requirement
-            name="org.eclipse.collections.feature.source.feature.group"
-            versionRange="[10.1.0,11.0.0)"/>
-        <repositoryList
-            name="10.2.0">
-          <repository
-              url="http://download.eclipse.org/collections/10.2.0/repository"/>
         </repositoryList>
       </targlet>
       <targlet

--- a/releng/org.eclipse.viatra.target.all/org.eclipse.viatra.target.all.target
+++ b/releng/org.eclipse.viatra.target.all/org.eclipse.viatra.target.all.target
@@ -36,12 +36,9 @@
 <unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.18.0.202106091000"/>
 <unit id="org.eclipse.uml2.sdk.feature.group" version="5.5.2.v20210228-1829"/>
 <unit id="org.eclipse.zest.sdk.feature.group" version="1.7.0.201606061308"/>
+<unit id="org.eclipse.collections" version="11.0.0.v20211123-1459"/>
 <unit id="org.junit" version="4.13.2.v20211018-1956"/>
 <repository location="https://download.eclipse.org/releases/2022-06/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-  <unit id="org.eclipse.collections.feature.feature.group" version="10.1.0.v20200211-1558"/>
-  <repository location="https://download.eclipse.org/collections/10.2.0/repository"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.viatra.examples.cps.metamodel.feature.feature.group" version="2.0.0.201801280931"/>


### PR DESCRIPTION
SimRel 2022-06 contains Eclipse Collections version 11.1.0, so updating the minimum dependency to this makes the range consistent with the current releases.

In case of the MANIFEST.MF entry in the matchers project version 11.0.0 is used as a dependency, as the manifest version was not updated correctly for release 11.1.0.