### PR TITLE
Replaces sonar jacoco report path #162

### DIFF
--- a/releng/org.eclipse.viatra.parent/pom.xml
+++ b/releng/org.eclipse.viatra.parent/pom.xml
@@ -32,7 +32,7 @@
 		<viatra.deploy.snapshot>https://repo.eclipse.org/content/repositories/viatra2-snapshots/</viatra.deploy.snapshot>
 		<!-- Sonar -->
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
-		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+		<sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/../org.eclipse.viatra.testreports/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 	<build>
 		<plugins>


### PR DESCRIPTION
The solution relies on the ${maven.multiModuleProjectDirectory} maven property that points to the parent.all projects directory (available since Maven 3.3). Hopefully this will result in Sonar picking up the aggregated coverage report.