### PR TITLE
Adds query initialization information to IQuerySpecification #106

### DIFF
--- a/query/plugins/org.eclipse.viatra.query.patternlanguage.emf.ui/src/org/eclipse/viatra/query/tooling/ui/queryresult/QueryResultTreeInput.xtend
+++ b/query/plugins/org.eclipse.viatra.query.patternlanguage.emf.ui/src/org/eclipse/viatra/query/tooling/ui/queryresult/QueryResultTreeInput.xtend
@@ -236,7 +236,7 @@ class QueryResultTreeInput implements IFilteredMatcherCollection {
         }
         try{
             val specification = entry.provider.specificationOfProvider as IQuerySpecification
-            if(specification.internalQueryRepresentation.status == PQueryStatus.ERROR){
+            if(specification.status == PQueryStatus.ERROR){
                 entry.addErroneousMatcher(new IllegalArgumentException("Query definition contains errors"))
             } else {
                 val currentHint = hintForBackendSelection.overrideBy(RuntimePreferencesInterpreter.getHintOverridesFromPreferences()) 

--- a/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/specification/internal/NameToSpecificationMap.java
+++ b/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/specification/internal/NameToSpecificationMap.java
@@ -150,6 +150,6 @@ public class NameToSpecificationMap implements Map<String, IQuerySpecification<?
     }
     
     private Stream<IQuerySpecification<?>> getSpecificationStreamWithStatus(final PQueryStatus status) {
-        return map.values().stream().filter(specification -> specification.getInternalQueryRepresentation().getStatus().equals(status));
+        return map.values().stream().filter(specification -> specification.getStatus().equals(status));
     }
 }

--- a/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/util/AdvancedPatternParsingResults.java
+++ b/query/plugins/org.eclipse.viatra.query.patternlanguage.emf/src/org/eclipse/viatra/query/patternlanguage/emf/util/AdvancedPatternParsingResults.java
@@ -125,7 +125,7 @@ public class AdvancedPatternParsingResults {
         return Lists
                 .newArrayList(Iterables.concat(addedSpecifications, updatedSpecifications, removedSpecifications,
                         impactedSpecifications))
-                .stream().filter(spec -> spec.getInternalQueryRepresentation().getStatus().equals(PQueryStatus.ERROR))
+                .stream().filter(spec -> spec.getStatus().equals(PQueryStatus.ERROR))
                 .collect(Collectors.toList());
     }
 

--- a/query/plugins/org.eclipse.viatra.query.runtime/.settings/.api_filters
+++ b/query/plugins/org.eclipse.viatra.query.runtime/.settings/.api_filters
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.viatra.query.runtime" version="2">
+    <resource path="src/org/eclipse/viatra/query/runtime/api/IQuerySpecification.java" type="org.eclipse.viatra.query.runtime.api.IQuerySpecification">
+        <filter comment="The query specification instances are closely managed, this change won't cause incompatibilities" id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.viatra.query.runtime.api.IQuerySpecification"/>
+                <message_argument value="getPProblems()"/>
+            </message_arguments>
+        </filter>
+        <filter comment="The query specification instances are closely managed, this change won't cause incompatibilities" id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.viatra.query.runtime.api.IQuerySpecification"/>
+                <message_argument value="getStatus()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/viatra/query/runtime/api/impl/BaseMatcher.java" type="org.eclipse.viatra.query.runtime.api.impl.BaseMatcher">
         <filter comment="QueryResultWrapper has no API methods" id="576720909">
             <message_arguments>

--- a/query/plugins/org.eclipse.viatra.query.runtime/src/org/eclipse/viatra/query/runtime/api/IQuerySpecification.java
+++ b/query/plugins/org.eclipse.viatra.query.runtime/src/org/eclipse/viatra/query/runtime/api/IQuerySpecification.java
@@ -9,10 +9,14 @@
 
 package org.eclipse.viatra.query.runtime.api;
 
+import java.util.List;
+
 import org.eclipse.viatra.query.runtime.api.scope.QueryScope;
 import org.eclipse.viatra.query.runtime.emf.EMFScope;
 import org.eclipse.viatra.query.runtime.matchers.ViatraQueryRuntimeException;
+import org.eclipse.viatra.query.runtime.matchers.psystem.queries.PProblem;
 import org.eclipse.viatra.query.runtime.matchers.psystem.queries.PQuery;
+import org.eclipse.viatra.query.runtime.matchers.psystem.queries.PQuery.PQueryStatus;
 import org.eclipse.viatra.query.runtime.matchers.psystem.queries.PQueryHeader;
 
 /**
@@ -74,6 +78,26 @@ public interface IQuerySpecification<Matcher extends ViatraQueryMatcher<? extend
      * @return the internal representation of the query.
      */
     public PQuery getInternalQueryRepresentation();
+    
+    /**
+     * Returns the initialization status of the query specification
+     * @see PQuery#getStatus() 
+     * @since 2.9
+     */
+    default PQueryStatus getStatus() {
+        return getInternalQueryRepresentation().getStatus();
+    }
+    
+    /**
+     * Returns a list describing the problems that were found in this query.
+     * 
+     * @return a non-null, but possibly empty list of problems
+     * @see PQuery#getPProblems()
+     * @since 2.9
+     */
+    default List<PProblem> getPProblems() {
+        return getInternalQueryRepresentation().getPProblems();
+    }
     
     /**
      * Creates a new uninitialized matcher, which is not functional until an engine initializes it. Clients

--- a/query/tests/org.eclipse.viatra.query.patternlanguage.emf.tests/src/org/eclipse/viatra/query/patternlanguage/emf/tests/standalone/AdvancedPatternParserTest.xtend
+++ b/query/tests/org.eclipse.viatra.query.patternlanguage.emf.tests/src/org/eclipse/viatra/query/patternlanguage/emf/tests/standalone/AdvancedPatternParserTest.xtend
@@ -49,7 +49,7 @@ class AdvancedPatternParserTest {
 
         val results = PatternParserBuilder.instance.buildAdvanced.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 1)
 
     }
 
@@ -74,7 +74,7 @@ class AdvancedPatternParserTest {
 
         val results = PatternParserBuilder.instance.buildAdvanced.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.ERROR].size === 2)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.ERROR].size === 2)
 
     }
 
@@ -108,7 +108,7 @@ class AdvancedPatternParserTest {
 
         val results = PatternParserBuilder.instance.buildAdvanced.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 2)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 2)
 
     }
     
@@ -200,7 +200,7 @@ class AdvancedPatternParserTest {
         var results = parser.addSpecifications(input);
         
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 1)
         assertTrue('''Erroneous Specifications: expected: 0 result: «results.erroneousSpecifications.size»''',
             results.erroneousSpecifications.size === 0)
         assertTrue('''Registered Uris: expected: 1 result: «parser.registeredURIs.size»''',
@@ -213,7 +213,7 @@ class AdvancedPatternParserTest {
         results = parser.addSpecifications(input);
         
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 1)
         assertTrue('''Erroneous Specifications: expected: 0 result: «results.erroneousSpecifications.size»''',
             results.erroneousSpecifications.size === 0)
         assertTrue('''Registered Uris: expected: 1 result: «parser.registeredURIs.size»''',
@@ -250,7 +250,7 @@ class AdvancedPatternParserTest {
 
         val results = PatternParserBuilder.instance.buildAdvanced.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 2)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 2)
     }
 
    @Test
@@ -285,7 +285,7 @@ class AdvancedPatternParserTest {
 
         val results = parser.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 2)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 2)
             
         val uri3 = URI.createURI('''__synthetic_pattern3''').resolve(URI.createFileURI(System.getProperty("user.dir")))
         
@@ -294,7 +294,7 @@ class AdvancedPatternParserTest {
         
         val results2 = parser.addSpecifications(input)
         assertTrue(
-            results2.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.ERROR].size === 1)
+            results2.getAddedSpecifications.filter[it.status === PQueryStatus.ERROR].size === 1)
     }
 
     
@@ -330,15 +330,15 @@ class AdvancedPatternParserTest {
 
         val results = parser.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 2)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 2)
             
         input.remove(uri2)
         
         val removedResults = parser.removeSpecifications(input)
         assertTrue(
-            removedResults.getRemovedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+            removedResults.getRemovedSpecifications.filter[it.status === PQueryStatus.OK].size === 1)
         assertTrue(
-            removedResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.ERROR].size === 1)
+            removedResults.getImpactedSpecifications.filter[it.status === PQueryStatus.ERROR].size === 1)
     }
     
     @Test
@@ -385,7 +385,7 @@ class AdvancedPatternParserTest {
 
         val results = parser.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 3)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 3)
         assertTrue('''Erroneous Specifications: expected: 0 result: «results.erroneousSpecifications.size»''',
             results.erroneousSpecifications.size === 0)
         assertTrue('''Registered Uris: expected: 3 result: «parser.registeredURIs.size»''',
@@ -397,9 +397,9 @@ class AdvancedPatternParserTest {
         
         val removedResults = parser.removeSpecifications(input)
         assertTrue(
-            removedResults.getRemovedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+            removedResults.getRemovedSpecifications.filter[it.status === PQueryStatus.OK].size === 1)
         assertTrue(
-            removedResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.ERROR].size === 2)
+            removedResults.getImpactedSpecifications.filter[it.status === PQueryStatus.ERROR].size === 2)
         assertTrue('''Erroneous Specifications: expected: 2 result: «removedResults.erroneousSpecifications.size»''',
             removedResults.erroneousSpecifications.size === 2)
         assertTrue('''Registered Uris: expected: 2 result: «parser.registeredURIs.size»''',
@@ -411,9 +411,9 @@ class AdvancedPatternParserTest {
         val reAddResults = parser.addSpecifications(input);
         
         assertTrue(
-            reAddResults.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+            reAddResults.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 1)
         assertTrue(
-            reAddResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 2)
+            reAddResults.getImpactedSpecifications.filter[it.status === PQueryStatus.OK].size === 2)
         assertTrue('''Erroneous Specifications: expected: 0 result: «reAddResults.erroneousSpecifications.size»''',
             reAddResults.erroneousSpecifications.size === 0)
         assertTrue('''Registered Uris: expected: 3 result: «parser.registeredURIs.size»''',
@@ -464,7 +464,7 @@ class AdvancedPatternParserTest {
 
         val results = parser.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 3)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 3)
          
         input.clear    
         val String updatedPattern1 = '''
@@ -481,9 +481,9 @@ class AdvancedPatternParserTest {
         
         val updatedResults = parser.updateSpecifications(input)
         assertTrue(
-            updatedResults.getUpdatedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+            updatedResults.getUpdatedSpecifications.filter[it.status === PQueryStatus.OK].size === 1)
         assertTrue(
-            updatedResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.ERROR].size === 2)
+            updatedResults.getImpactedSpecifications.filter[it.status === PQueryStatus.ERROR].size === 2)
             
         input.clear    
         input.put(uri1, pattern1)  
@@ -491,9 +491,9 @@ class AdvancedPatternParserTest {
         val reAddResults = parser.updateSpecifications(input);
         
         assertTrue(
-            reAddResults.getUpdatedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+            reAddResults.getUpdatedSpecifications.filter[it.status === PQueryStatus.OK].size === 1)
         assertTrue(
-            reAddResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 2)
+            reAddResults.getImpactedSpecifications.filter[it.status === PQueryStatus.OK].size === 2)
             
     }
     
@@ -533,14 +533,14 @@ class AdvancedPatternParserTest {
 
         val results = parser.addSpecifications(input);
         assertEquals(2,
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size)
          
         input.clear    
         input.put(uri, afterRemoval)
         
         val updatedResults = parser.updateSpecifications(input)
         assertEquals(1,
-            updatedResults.getUpdatedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size)
+            updatedResults.getUpdatedSpecifications.filter[it.status === PQueryStatus.OK].size)
         assertEquals(1,
             updatedResults.getRemovedSpecifications.size)
     }
@@ -579,7 +579,7 @@ class AdvancedPatternParserTest {
 
         val results = parser.addSpecifications(input);
         assertTrue(
-            results.getAddedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 2)
+            results.getAddedSpecifications.filter[it.status === PQueryStatus.OK].size === 2)
          
         input.clear    
         val String updatedPattern1 = '''
@@ -600,9 +600,9 @@ class AdvancedPatternParserTest {
         
         val updatedResults = parser.updateSpecifications(input)
         assertEquals(2,
-            updatedResults.getUpdatedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size)
+            updatedResults.getUpdatedSpecifications.filter[it.status === PQueryStatus.OK].size)
         assertEquals(0,
-            updatedResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.ERROR].size)
+            updatedResults.getImpactedSpecifications.filter[it.status === PQueryStatus.ERROR].size)
             
         input.clear    
         val String updatedPattern2 = '''
@@ -620,21 +620,21 @@ class AdvancedPatternParserTest {
         val readdWithDifferentNameResults = parser.updateSpecifications(input);
         
         assertEquals(1,
-            readdWithDifferentNameResults.getUpdatedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size)
+            readdWithDifferentNameResults.getUpdatedSpecifications.filter[it.status === PQueryStatus.OK].size)
         assertEquals(1,
-            readdWithDifferentNameResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size)
+            readdWithDifferentNameResults.getImpactedSpecifications.filter[it.status === PQueryStatus.OK].size)
         assertEquals(1,
-            readdWithDifferentNameResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.ERROR].size)
+            readdWithDifferentNameResults.getImpactedSpecifications.filter[it.status === PQueryStatus.ERROR].size)
             
         input.put(uri2, pattern2)
         
         val fixedCalledNameResults = parser.updateSpecifications(input)
         assertEquals(1,
-            fixedCalledNameResults.getUpdatedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size)
+            fixedCalledNameResults.getUpdatedSpecifications.filter[it.status === PQueryStatus.OK].size)
         assertEquals(2,
-            fixedCalledNameResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size)
+            fixedCalledNameResults.getImpactedSpecifications.filter[it.status === PQueryStatus.OK].size)
         assertEquals(0,
-            fixedCalledNameResults.getImpactedSpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.ERROR].size)
+            fixedCalledNameResults.getImpactedSpecifications.filter[it.status === PQueryStatus.ERROR].size)
             
     }
     
@@ -665,14 +665,14 @@ class AdvancedPatternParserTest {
 
         val results = parser.addSpecifications(input);
         assertEquals(
-            2, results.getAddedSpecifications.filter[internalQueryRepresentation.status === PQueryStatus.OK].size)
+            2, results.getAddedSpecifications.filter[status === PQueryStatus.OK].size)
          
         val afterDeleteResults = parser.removeSpecifications(input)
         
         assertEquals(
-            0, afterDeleteResults.getUpdatedSpecifications.filter[internalQueryRepresentation.status === PQueryStatus.OK].size)
+            0, afterDeleteResults.getUpdatedSpecifications.filter[status === PQueryStatus.OK].size)
         assertEquals(
-            0, afterDeleteResults.getImpactedSpecifications.filter[internalQueryRepresentation.status === PQueryStatus.OK].size)
+            0, afterDeleteResults.getImpactedSpecifications.filter[status === PQueryStatus.OK].size)
             
     }
     
@@ -711,14 +711,14 @@ class AdvancedPatternParserTest {
 
         val results = parser.addSpecifications(input);
         assertEquals(
-            2, results.getAddedSpecifications.filter[internalQueryRepresentation.status === PQueryStatus.OK].size)
+            2, results.getAddedSpecifications.filter[status === PQueryStatus.OK].size)
          
         val afterDeleteResults = parser.removeSpecifications(input)
         
         assertEquals(
-            0, afterDeleteResults.getUpdatedSpecifications.filter[internalQueryRepresentation.status === PQueryStatus.OK].size)
+            0, afterDeleteResults.getUpdatedSpecifications.filter[status === PQueryStatus.OK].size)
         assertEquals(
-            0, afterDeleteResults.getImpactedSpecifications.filter[internalQueryRepresentation.status === PQueryStatus.OK].size)
+            0, afterDeleteResults.getImpactedSpecifications.filter[status === PQueryStatus.OK].size)
             
     }
     
@@ -770,7 +770,7 @@ class AdvancedPatternParserTest {
         val usingLibraryUri = URI.createURI("usingLibrary")
 
         val results = new PatternParserBuilder().withLibrary(libraryUri).buildAdvanced.addSpecifications(usingLibraryUri, usingLibrarySource)
-        assertEquals(1, results.addedSpecifications.filter[internalQueryRepresentation.status === PQueryStatus.OK].size)
+        assertEquals(1, results.addedSpecifications.filter[status === PQueryStatus.OK].size)
     }
     
     @Rule

--- a/query/tests/org.eclipse.viatra.query.patternlanguage.emf.tests/src/org/eclipse/viatra/query/patternlanguage/emf/tests/standalone/PatternParserTest.xtend
+++ b/query/tests/org.eclipse.viatra.query.patternlanguage.emf.tests/src/org/eclipse/viatra/query/patternlanguage/emf/tests/standalone/PatternParserTest.xtend
@@ -38,7 +38,7 @@ class PatternParserTest {
             }
         '''
         val results = PatternParser.parser.parse(pattern) 
-        assertTrue(results.querySpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].size === 1)
+        assertTrue(results.querySpecifications.filter[it.status === PQueryStatus.OK].size === 1)
         assertFalse(results.hasError)
     }
     
@@ -52,7 +52,7 @@ class PatternParserTest {
             }
         '''
         val results = PatternParser.parser.parse(pattern)
-        assertTrue(results.querySpecifications.filter[it.internalQueryRepresentation.status === PQueryStatus.OK].isEmpty)
+        assertTrue(results.querySpecifications.filter[it.status === PQueryStatus.OK].isEmpty)
         assertTrue(results.hasError)
     }
     
@@ -67,8 +67,8 @@ class PatternParserTest {
             }
         '''
         val results = PatternParser.parser.parse(pattern)
-        assertTrue(results.querySpecifications.forall[it.internalQueryRepresentation.status === PQueryStatus.ERROR])
-        results.querySpecifications.map[it.internalQueryRepresentation.PProblems].flatten.exists[location.contains("Line 5")]
+        assertTrue(results.querySpecifications.forall[it.status === PQueryStatus.ERROR])
+        results.querySpecifications.map[it.PProblems].flatten.exists[location.contains("Line 5")]
         assertTrue(results.hasError)
     }
     
@@ -87,8 +87,8 @@ class PatternParserTest {
             }
         '''
         val results = PatternParser.parser.parse(pattern)
-        assertFalse(results.querySpecifications.forall[it.internalQueryRepresentation.status === PQueryStatus.OK])
-        assertTrue(results.querySpecifications.forall[it.internalQueryRepresentation.status === PQueryStatus.ERROR])
+        assertFalse(results.querySpecifications.forall[it.status === PQueryStatus.OK])
+        assertTrue(results.querySpecifications.forall[it.status === PQueryStatus.ERROR])
         assertTrue(results.hasError)
     }
     
@@ -105,8 +105,8 @@ class PatternParserTest {
         parser.enableReuseSpecificationBuilder(true)
         val results1 = parser.parse(pattern)
         val results2 = parser.parse(pattern)
-        assertTrue(results1.querySpecifications.forall[it.internalQueryRepresentation.status === PQueryStatus.OK])
-        assertTrue(results2.querySpecifications.forall[it.internalQueryRepresentation.status === PQueryStatus.ERROR])
+        assertTrue(results1.querySpecifications.forall[it.status === PQueryStatus.OK])
+        assertTrue(results2.querySpecifications.forall[it.status === PQueryStatus.ERROR])
         assertTrue(results2.hasError)
     }
     

--- a/query/tests/org.eclipse.viatra.query.runtime.cps.tests/src/org/eclipse/viatra/query/runtime/cps/tests/api/GenericMatcherTest.xtend
+++ b/query/tests/org.eclipse.viatra.query.runtime.cps.tests/src/org/eclipse/viatra/query/runtime/cps/tests/api/GenericMatcherTest.xtend
@@ -63,7 +63,7 @@ class GenericMatcherTest {
         '''
         val results = PatternParserBuilder.instance.parse(pattern) 
         val querySpecification = results.getQuerySpecification("b").get
-        assertTrue(querySpecification.internalQueryRepresentation.status == PQueryStatus.ERROR)
+        assertTrue(querySpecification.status == PQueryStatus.ERROR)
         ViatraQueryEngine.on(getScope()).getMatcher(querySpecification)
     }
 }


### PR DESCRIPTION
This change adds two new default methods to the IQuerySpecification interface that makes internal PQuery information available without relying on accessing the PQuery instance.

Furthermore, the uses of this feature were replaced with the new functionality.